### PR TITLE
Fix waitlist participants display confusion

### DIFF
--- a/frontend/src/routes/Waitlist.svelte
+++ b/frontend/src/routes/Waitlist.svelte
@@ -442,9 +442,6 @@
                   </div>
                 </div>
               </div>
-              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800">
-                #{user.waitlistRank}
-              </span>
             </div>
           {/each}
         </div>


### PR DESCRIPTION
## Summary
Removed rank badges from the "Newest Waitlist Participants" section to eliminate confusion between competitive leaderboard rankings and chronological order of recent joiners.

## Problem
The "Newest Waitlist Participants" section was displaying rank badges alongside each participant. These numbers represented their current competitive rank in the waitlist leaderboard based on points, not their order of joining. This created confusion as users expected the numbers to reflect the chronological order in a section specifically labeled for showing the newest participants.

## Solution
Removed the rank badges from this section. The section now clearly shows only:
- Participant name and avatar
- Date they joined the waitlist

The alternative would be showing the early builder batch as proposed in #118.

The competitive ranks are still properly displayed in the "Race to Testnet Asimov" section where they belong.

Fixes #108