### PR TITLE
Fix: Add avatar display in accept contributions view

### DIFF
--- a/frontend/src/components/SubmissionCard.svelte
+++ b/frontend/src/components/SubmissionCard.svelte
@@ -4,6 +4,7 @@
   import ContributionCard from './ContributionCard.svelte';
   import ContributionSelection from '../lib/components/ContributionSelection.svelte';
   import Link from '../lib/components/Link.svelte';
+  import Avatar from './Avatar.svelte';
   
   let { 
     submission,
@@ -173,7 +174,14 @@
           {#if isOwnSubmission}
             {submission.contribution_type_name || getTypeName(submission.contribution_type)}
           {:else}
-            {submission.user_details?.name || submission.user_details?.address?.slice(0, 8) + '...'}
+            <div class="flex items-center gap-2">
+              <Avatar
+                user={submission.user_details}
+                size="sm"
+                clickable={true}
+              />
+              <span>{submission.user_details?.name || submission.user_details?.address?.slice(0, 8) + '...'}</span>
+            </div>
           {/if}
         </h3>
         <p class="text-sm text-gray-600">
@@ -195,10 +203,15 @@
           <div>
             <h4 class="text-sm font-medium text-gray-700">User</h4>
             <div class="mt-1 flex items-center gap-3">
+              <Avatar
+                user={submission.user_details}
+                size="xs"
+                clickable={true}
+              />
               <span class="text-sm text-gray-900">
                 {submission.user_details?.name || submission.user_details?.address?.slice(0, 8) + '...'}
               </span>
-              <Link 
+              <Link
                 href="/participant/{submission.user_details?.address}"
                 class="text-xs text-primary-600 hover:text-primary-700 hover:underline"
               >
@@ -303,16 +316,22 @@
                       <label class="block text-sm font-medium text-gray-700">
                         Assign Contribution To
                       </label>
-                      <select
-                        bind:value={selectedUser}
-                        class="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-white"
-                      >
-                        {#each users as user}
-                          <option value={user.id}>
-                            {user.display_name}
-                          </option>
-                        {/each}
-                      </select>
+                      <div class="mt-1 flex items-center gap-2">
+                        <Avatar
+                          user={users.find(u => u.id === selectedUser)}
+                          size="sm"
+                        />
+                        <select
+                          bind:value={selectedUser}
+                          class="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm bg-white"
+                        >
+                          {#each users as user}
+                            <option value={user.id}>
+                              {user.display_name}
+                            </option>
+                          {/each}
+                        </select>
+                      </div>
                       <p class="text-xs text-gray-500 mt-1">
                         The contribution will be assigned to this user
                       </p>


### PR DESCRIPTION
## Summary
- Added Avatar component to SubmissionCard for consistent user identification
- Displays user avatars in submission headers, user details, and dropdown selection
- Fixes issue where validators with avatars but no names only showed address text

## Changes
- Import Avatar component into SubmissionCard.svelte
- Add avatar display next to user name in submission header (for non-own submissions)
- Add avatar display in user details section when reviewing submissions
- Add avatar display in user selection dropdown when assigning contributions

## Test Plan
- [x] Frontend builds successfully without errors
- [x] Avatar component properly imported and integrated
- [x] Consistent avatar sizing (sm for header, xs for details)
- [x] Clickable avatars navigate to user profile

Fixes #144