### PR TITLE
Add GitHub OAuth environment variables to deployment scripts

### DIFF
--- a/backend/deploy-apprunner-dev.sh
+++ b/backend/deploy-apprunner-dev.sh
@@ -64,7 +64,13 @@ if aws apprunner describe-service --service-arn arn:aws:apprunner:$REGION:$ACCOU
           "ALLOWED_CIDR_NETS": "$SSM_PREFIX/$SSM_ENV/allowed_cidr_nets",
           "CLOUDINARY_CLOUD_NAME": "$SSM_PREFIX/$SSM_ENV/cloudinary_cloud_name",
           "CLOUDINARY_API_KEY": "$SSM_PREFIX/$SSM_ENV/cloudinary_api_key",
-          "CLOUDINARY_API_SECRET": "$SSM_PREFIX/$SSM_ENV/cloudinary_api_secret"
+          "CLOUDINARY_API_SECRET": "$SSM_PREFIX/$SSM_ENV/cloudinary_api_secret",
+          "BACKEND_URL": "$SSM_PREFIX/$SSM_ENV/backend_url",
+          "FRONTEND_URL": "$SSM_PREFIX/$SSM_ENV/frontend_url",
+          "GITHUB_CLIENT_ID": "$SSM_PREFIX/$SSM_ENV/github_client_id",
+          "GITHUB_CLIENT_SECRET": "$SSM_PREFIX/$SSM_ENV/github_client_secret",
+          "GITHUB_ENCRYPTION_KEY": "$SSM_PREFIX/$SSM_ENV/github_encryption_key",
+          "GITHUB_REPO_TO_STAR": "$SSM_PREFIX/$SSM_ENV/github_repo_to_star"
         },
         "StartCommand": "./startup.sh gunicorn --bind 0.0.0.0:8000 --timeout 180 --workers 2 tally.wsgi:application"
       },
@@ -211,7 +217,13 @@ EOF
           "ALLOWED_CIDR_NETS": "$SSM_PREFIX/$SSM_ENV/allowed_cidr_nets",
           "CLOUDINARY_CLOUD_NAME": "$SSM_PREFIX/$SSM_ENV/cloudinary_cloud_name",
           "CLOUDINARY_API_KEY": "$SSM_PREFIX/$SSM_ENV/cloudinary_api_key",
-          "CLOUDINARY_API_SECRET": "$SSM_PREFIX/$SSM_ENV/cloudinary_api_secret"
+          "CLOUDINARY_API_SECRET": "$SSM_PREFIX/$SSM_ENV/cloudinary_api_secret",
+          "BACKEND_URL": "$SSM_PREFIX/$SSM_ENV/backend_url",
+          "FRONTEND_URL": "$SSM_PREFIX/$SSM_ENV/frontend_url",
+          "GITHUB_CLIENT_ID": "$SSM_PREFIX/$SSM_ENV/github_client_id",
+          "GITHUB_CLIENT_SECRET": "$SSM_PREFIX/$SSM_ENV/github_client_secret",
+          "GITHUB_ENCRYPTION_KEY": "$SSM_PREFIX/$SSM_ENV/github_encryption_key",
+          "GITHUB_REPO_TO_STAR": "$SSM_PREFIX/$SSM_ENV/github_repo_to_star"
         },
         "StartCommand": "./startup.sh gunicorn --bind 0.0.0.0:8000 --timeout 180 --workers 2 tally.wsgi:application"
       },

--- a/backend/deploy-apprunner.sh
+++ b/backend/deploy-apprunner.sh
@@ -203,7 +203,13 @@ if aws apprunner describe-service --service-arn arn:aws:apprunner:$REGION:$ACCOU
           "ALLOWED_CIDR_NETS": "$SSM_PREFIX/prod/allowed_cidr_nets",
           "CLOUDINARY_CLOUD_NAME": "$SSM_PREFIX/prod/cloudinary_cloud_name",
           "CLOUDINARY_API_KEY": "$SSM_PREFIX/prod/cloudinary_api_key",
-          "CLOUDINARY_API_SECRET": "$SSM_PREFIX/prod/cloudinary_api_secret"
+          "CLOUDINARY_API_SECRET": "$SSM_PREFIX/prod/cloudinary_api_secret",
+          "BACKEND_URL": "$SSM_PREFIX/prod/backend_url",
+          "FRONTEND_URL": "$SSM_PREFIX/prod/frontend_url",
+          "GITHUB_CLIENT_ID": "$SSM_PREFIX/prod/github_client_id",
+          "GITHUB_CLIENT_SECRET": "$SSM_PREFIX/prod/github_client_secret",
+          "GITHUB_ENCRYPTION_KEY": "$SSM_PREFIX/prod/github_encryption_key",
+          "GITHUB_REPO_TO_STAR": "$SSM_PREFIX/prod/github_repo_to_star"
         },
         "StartCommand": "./startup.sh gunicorn --bind 0.0.0.0:8000 --timeout 180 --workers 2 tally.wsgi:application"
       },
@@ -277,7 +283,13 @@ else
           "ALLOWED_CIDR_NETS": "$SSM_PREFIX/prod/allowed_cidr_nets",
           "CLOUDINARY_CLOUD_NAME": "$SSM_PREFIX/prod/cloudinary_cloud_name",
           "CLOUDINARY_API_KEY": "$SSM_PREFIX/prod/cloudinary_api_key",
-          "CLOUDINARY_API_SECRET": "$SSM_PREFIX/prod/cloudinary_api_secret"
+          "CLOUDINARY_API_SECRET": "$SSM_PREFIX/prod/cloudinary_api_secret",
+          "BACKEND_URL": "$SSM_PREFIX/prod/backend_url",
+          "FRONTEND_URL": "$SSM_PREFIX/prod/frontend_url",
+          "GITHUB_CLIENT_ID": "$SSM_PREFIX/prod/github_client_id",
+          "GITHUB_CLIENT_SECRET": "$SSM_PREFIX/prod/github_client_secret",
+          "GITHUB_ENCRYPTION_KEY": "$SSM_PREFIX/prod/github_encryption_key",
+          "GITHUB_REPO_TO_STAR": "$SSM_PREFIX/prod/github_repo_to_star"
         },
         "StartCommand": "./startup.sh gunicorn --bind 0.0.0.0:8000 --timeout 180 --workers 2 tally.wsgi:application"
       },


### PR DESCRIPTION
## Summary
- Added GitHub OAuth configuration parameters to SSM retrieval in deployment scripts
- Updated both production and dev deployment configurations
- Includes BACKEND_URL, FRONTEND_URL, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_ENCRYPTION_KEY, and GITHUB_REPO_TO_STAR

## Changes
- `backend/deploy-apprunner.sh`: Added 6 new environment secrets from SSM for GitHub OAuth
- `backend/deploy-apprunner-dev.sh`: Added 6 new environment secrets from SSM for GitHub OAuth

## Test Plan
- Deploy to staging/dev environment and verify GitHub OAuth functionality
- Confirm environment variables are properly retrieved from SSM Parameter Store