### PR TITLE
Fix contribution filtering in Profile page role sections

### DIFF
--- a/frontend/src/routes/Profile.svelte
+++ b/frontend/src/routes/Profile.svelte
@@ -1055,6 +1055,7 @@
               title="Recent Contributions"
               limit={5}
               userId={participant.address}
+              category="validator"
               showHeader={true}
               showViewAll={true}
               viewAllPath={`/all-contributions?user=${participant.address}&category=validator`}
@@ -1120,6 +1121,7 @@
               title="Recent Contributions"
               limit={5}
               userId={participant.address}
+              category="builder"
               showHeader={true}
               showViewAll={true}
               viewAllPath={`/all-contributions?user=${participant.address}&category=builder`}
@@ -1129,7 +1131,7 @@
         </div>
       </div>
     {/if}
-    
+
     <!-- Validator Waitlist Card -->
     {#if participant.has_validator_waitlist && !participant.validator}
       <div class="bg-sky-50 rounded-lg shadow-sm border border-sky-200 overflow-hidden mb-6">
@@ -1199,6 +1201,7 @@
               title="Recent Contributions"
               limit={5}
               userId={participant.address}
+              category="validator"
               showHeader={true}
               showViewAll={true}
               viewAllPath={`/all-contributions?user=${participant.address}&category=validator`}
@@ -1208,7 +1211,7 @@
         </div>
       </div>
     {/if}
-    
+
     <!-- Builder Welcome Card -->
     {#if participant.has_builder_welcome && !participant.builder}
       <div class="bg-orange-50 rounded-lg shadow-sm border border-orange-200 overflow-hidden mb-6">
@@ -1283,6 +1286,7 @@
               title="Recent Contributions"
               limit={5}
               userId={participant.address}
+              category="builder"
               showHeader={true}
               showViewAll={true}
               viewAllPath={`/all-contributions?user=${participant.address}&category=builder`}


### PR DESCRIPTION
## Summary
Fixes an issue where validator and builder sections in the Profile page were showing mixed contributions instead of role-specific ones.

## Changes
- Added explicit `category` prop to `RecentContributions` component
- Updated filtering logic to use explicit category prop when provided, falling back to global store otherwise
- Pass `category="validator"` and `category="builder"` props in Profile page role sections

## Problem
The `RecentContributions` component was using the global `$currentCategory` store to filter contributions. When displayed in the Profile page for users with multiple roles (e.g., both validator and builder), both sections showed the same contributions based on the global category instead of their respective ones.

## Solution
Each role section now explicitly specifies its category, ensuring validator sections show only validator contributions and builder sections show only builder contributions, regardless of global category selection.