### PR TITLE
Display user name instead of address in auth button

### DIFF
--- a/frontend/src/components/AuthButton.svelte
+++ b/frontend/src/components/AuthButton.svelte
@@ -127,7 +127,7 @@
     {#if loading || storeLoading}
       <span class="loading-spinner"></span>
     {:else if isAuthenticated}
-      <span class="address">{formatAddress(address)}</span>
+      <span class="address">{$userStore.user?.name || formatAddress(address)}</span>
       <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
       </svg>


### PR DESCRIPTION
Show user's display name in the green auth button instead of truncated address. Falls back to address if no name is set.