### PR TITLE
Add Supporters section with referral points leaderboard

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -44,7 +44,8 @@
   import TermsOfUse from './routes/TermsOfUse.svelte';
   import PrivacyPolicy from './routes/PrivacyPolicy.svelte';
   import Referrals from './routes/Referrals.svelte';
-  
+  import Supporters from './routes/Supporters.svelte';
+
   // Define routes
   const routes = {
 
@@ -62,6 +63,7 @@
     '/leaderboard': Leaderboard,
     '/participants': Validators,
     '/referrals': Referrals,
+    '/supporters': Supporters,
 
     // Builders routes
     '/builders': Dashboard,

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -276,7 +276,28 @@
         </div>
         {/if}
       </div>
-      
+
+      <!-- Supporters section -->
+      <div>
+        <div class="border-t border-gray-200 mb-3"></div>
+        <a
+          href="/supporters"
+          onclick={(e) => { e.preventDefault(); navigate('/supporters'); }}
+          class="w-full flex items-center px-3 py-2 mb-1 rounded-md transition-colors {
+            isActive('/supporters')
+              ? 'bg-purple-50 text-purple-600'
+              : 'hover:bg-gray-50'
+          }"
+        >
+          <svg class="w-4 h-4 mr-2 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+          </svg>
+          <h3 class="text-xs font-medium uppercase tracking-wider flex-1 text-left {isActive('/supporters') ? 'text-purple-700' : 'text-gray-700'}">
+            SUPPORTERS
+          </h3>
+        </a>
+      </div>
+
       <!-- Profile section -->
       <div>
         <div class="border-t border-gray-200 mb-3"></div>
@@ -288,7 +309,7 @@
               : 'hover:bg-gray-50'
           }"
         >
-          <Icon 
+          <Icon
             name="profile"
             size="sm"
             className="mr-2 text-purple-600"
@@ -296,7 +317,7 @@
           <h3 class="text-xs font-medium uppercase tracking-wider flex-1 text-left text-gray-700">
             Profile
           </h3>
-          <Icon 
+          <Icon
             name="chevronDown"
             size="xs"
             className="text-gray-400"
@@ -476,7 +497,28 @@
           </div>
           {/if}
         </div>
-        
+
+        <!-- Supporters section -->
+        <div>
+          <div class="border-t border-gray-200 mb-3"></div>
+          <a
+            href="/supporters"
+            onclick={(e) => { e.preventDefault(); navigate('/supporters'); }}
+            class="w-full flex items-center px-3 py-2 mb-1 rounded-md transition-colors {
+              isActive('/supporters')
+                ? 'bg-purple-50 text-purple-600'
+                : 'hover:bg-gray-50'
+            }"
+          >
+            <svg class="w-4 h-4 mr-2 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+            </svg>
+            <h3 class="text-sm font-medium uppercase tracking-wider {isActive('/supporters') ? 'text-purple-700' : 'text-gray-700'}">
+              SUPPORTERS
+            </h3>
+          </a>
+        </div>
+
         <!-- Profile section -->
         <div>
           <div class="border-t border-gray-200 mb-3"></div>
@@ -488,7 +530,7 @@
                 : 'hover:bg-gray-50'
             }"
           >
-            <Icon 
+            <Icon
               name="profile"
               size="sm"
               className="mr-2 text-purple-600"

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -103,7 +103,7 @@ export const contributionsAPI = {
 // API endpoints for leaderboard
 export const leaderboardAPI = {
   getLeaderboard: (params) => api.get('/leaderboard/', { params }),
-  getLeaderboardByType: (type, order = 'asc') => 
+  getLeaderboardByType: (type, order = 'asc') =>
     api.get('/leaderboard/', { params: { type, order } }),
   getLeaderboardEntry: (address) => api.get(`/leaderboard/?user_address=${address}`),
   getMultipliers: () => api.get('/multipliers/'),
@@ -111,6 +111,7 @@ export const leaderboardAPI = {
   getMultiplierPeriods: (multiplier_id) => api.get(`/multiplier-periods/?multiplier=${multiplier_id}`),
   getStats: () => api.get('/leaderboard/stats/'),
   getWaitlistStats: () => api.get('/leaderboard/validator-waitlist-stats/'),
+  getSupporters: () => api.get('/leaderboard/supporters/'),
   getTypes: () => api.get('/leaderboard/types/'),
   recalculateAll: () => api.post('/leaderboard/recalculate/')
 };

--- a/frontend/src/routes/StewardDashboard.svelte
+++ b/frontend/src/routes/StewardDashboard.svelte
@@ -308,7 +308,7 @@
               <div class="bg-gray-50 rounded-lg p-4 border border-gray-200">
                 <p class="text-sm text-gray-600 mb-2">💡 <strong>Interested in joining?</strong></p>
                 <p class="text-sm text-gray-600">
-                  Contact <span class="font-mono bg-teal-100 px-1.5 py-0.5 rounded text-teal-700 font-semibold">@ras</span> on Discord or Telegram to learn more about upcoming working groups.
+                  Contact <span class="font-mono bg-teal-100 px-1.5 py-0.5 rounded text-teal-700 font-semibold">@ras</span> on <a href="https://discord.gg/jxJBeVEt" target="_blank" rel="noopener noreferrer" class="text-teal-600 hover:text-teal-700 underline font-semibold">Discord</a> to learn more about upcoming working groups.
                 </p>
               </div>
             </div>

--- a/frontend/src/routes/Supporters.svelte
+++ b/frontend/src/routes/Supporters.svelte
@@ -1,0 +1,141 @@
+<script>
+  import { onMount } from 'svelte';
+  import { push } from 'svelte-spa-router';
+  import Avatar from '../components/Avatar.svelte';
+  import Icon from '../components/Icons.svelte';
+  import { leaderboardAPI } from '../lib/api';
+
+  // State management
+  let supporters = $state([]);
+  let loading = $state(true);
+  let error = $state(null);
+
+  // Fetch supporters data
+  async function fetchSupporters() {
+    try {
+      loading = true;
+      error = null;
+
+      const response = await leaderboardAPI.getSupporters();
+      const data = response.data;
+
+      supporters = data.top_supporters || [];
+      loading = false;
+    } catch (err) {
+      console.error('Error fetching supporters:', err);
+      error = err.message || 'Failed to load supporters';
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    fetchSupporters();
+  });
+
+  function getRankClass(rank) {
+    if (rank === 1) return 'bg-amber-100 text-amber-800';
+    if (rank === 2) return 'bg-gray-100 text-gray-800';
+    if (rank === 3) return 'bg-amber-50 text-amber-700';
+    return 'bg-gray-50 text-gray-600';
+  }
+</script>
+
+<div class="space-y-6 sm:space-y-8">
+      <!-- Main Title -->
+      <h1 class="text-2xl font-bold text-gray-900">Supporters</h1>
+
+      <!-- Top Supporters Section -->
+      <div class="space-y-4">
+        <div class="flex items-center gap-2">
+          <div class="p-1.5 bg-purple-100 rounded-lg">
+            <svg class="w-4 h-4 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+            </svg>
+          </div>
+          <h2 class="text-lg font-semibold text-gray-900">Top Supporters</h2>
+        </div>
+
+      {#if loading}
+        <div class="flex justify-center items-center p-8">
+          <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+        </div>
+      {:else if error}
+        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+          <p>{error}</p>
+        </div>
+      {:else if supporters.length === 0}
+        <div class="bg-white shadow overflow-hidden rounded-lg p-12 text-center">
+          <div class="mx-auto w-16 h-16 bg-purple-100 rounded-full flex items-center justify-center mb-4">
+            <svg class="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+            </svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">No Supporters Yet</h3>
+          <p class="text-gray-600">Be the first to earn referral points by inviting people to the GenLayer ecosystem!</p>
+        </div>
+      {:else}
+        <div class="bg-white shadow overflow-hidden rounded-lg">
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Rank
+                  </th>
+                  <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Participant
+                  </th>
+                  <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Total Referral Points
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="bg-white divide-y divide-gray-200">
+                {#each supporters as supporter, i}
+                  <tr class={i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                      <span class={`inline-flex items-center justify-center h-8 w-8 rounded-full ${getRankClass(i + 1)}`}>
+                        {i + 1}
+                      </span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                      <div class="flex items-center">
+                        <div class="flex-shrink-0 mr-3">
+                          <Avatar
+                            user={supporter}
+                            size="sm"
+                            clickable={true}
+                          />
+                        </div>
+                        <button
+                          onclick={() => push(`/participant/${supporter.address}`)}
+                          class="text-sm font-medium text-gray-900 hover:text-primary-600 transition-colors"
+                        >
+                          {supporter.name || `${supporter.address.slice(0, 6)}...${supporter.address.slice(-4)}`}
+                        </button>
+                      </div>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                      <div class="flex items-center justify-center gap-2">
+                        <span class="text-lg font-bold text-gray-900">{supporter.total_points}</span>
+                        <div class="flex items-center gap-2">
+                          <div class="flex items-center text-xs text-orange-600" title="Builder Referral Points">
+                            <Icon name="builder" size="xs" className="mr-0.5" />
+                            {supporter.builder_points}
+                          </div>
+                          <div class="flex items-center text-xs text-sky-600" title="Validator Referral Points">
+                            <Icon name="validator" size="xs" className="mr-0.5" />
+                            {supporter.validator_points}
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      {/if}
+      </div>
+</div>

--- a/frontend/src/stores/category.js
+++ b/frontend/src/stores/category.js
@@ -20,9 +20,14 @@ export const categories = [
     name: 'Validators', 
     iconPath: 'M12 2L3.5 7v6c0 5.55 3.84 10.74 8.5 12 4.66-1.26 8.5-6.45 8.5-12V7L12 2zm1 6h-2v4H9l3 4 3-4h-2V8z'
   },
-  { 
-    id: 'steward', 
-    name: 'Stewards', 
+  {
+    id: 'steward',
+    name: 'Stewards',
+    iconPath: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z'
+  },
+  {
+    id: 'supporter',
+    name: 'Supporters',
     iconPath: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z'
   }
 ];
@@ -89,9 +94,24 @@ export const categoryTheme = derived(currentCategory, $category => {
       badge: 'bg-green-100 text-green-800',
       button: 'bg-green-600 hover:bg-green-700 text-white',
       buttonLight: 'bg-green-100 hover:bg-green-200 text-green-700'
+    },
+    supporter: {
+      // Purple theme
+      bg: 'bg-purple-50',
+      bgSecondary: 'bg-purple-100',
+      primary: 'bg-purple-600',
+      primaryHover: 'hover:bg-purple-700',
+      text: 'text-purple-600',
+      textLight: 'text-purple-500',
+      border: 'border-purple-200',
+      borderAccent: 'border-purple-300',
+      ring: 'focus:ring-purple-500',
+      badge: 'bg-purple-100 text-purple-800',
+      button: 'bg-purple-600 hover:bg-purple-700 text-white',
+      buttonLight: 'bg-purple-100 hover:bg-purple-200 text-purple-700'
     }
   };
-  
+
   return themes[$category] || themes.global;
 });
 
@@ -111,6 +131,8 @@ export function detectCategoryFromRoute(path) {
     return 'validator';
   } else if (path.startsWith('/stewards')) {
     return 'steward';
+  } else if (path.startsWith('/supporters')) {
+    return 'supporter';
   }
   return 'global';
 }


### PR DESCRIPTION
## Summary
- Add Supporters page showing top 10 users by total referral points
- Display builder and validator referral points breakdown with icons
- Add purple-themed Supporters category
- Add Supporters section to sidebar
- Update Stewards section Discord link

## Supporters Changes
- Created `/supporters` route with leaderboard table
- Backend endpoint returns top 10 supporters by total referral points
- Shows breakdown of builder and validator referral points
- Purple theme integration via category system
- Empty state invites users to earn first referral points

## Stewards Changes
- Updated Discord invite link to https://discord.gg/jxJBeVEt
- Removed Telegram reference