### PR TITLE
Fix undefined links in mission markdown rendering

### DIFF
--- a/frontend/src/components/Missions.svelte
+++ b/frontend/src/components/Missions.svelte
@@ -20,8 +20,11 @@
 
   // Configure marked options for security and links
   const renderer = new marked.Renderer();
-  renderer.link = function(href, title, text) {
-    return `<a href="${href}" target="_blank" rel="noopener noreferrer"${title ? ` title="${title}"` : ''}>${text}</a>`;
+  // In marked v5+, the renderer receives a token object
+  renderer.link = function({ href, title, text }) {
+    // Handle undefined/null href values
+    const safeHref = href || '#';
+    return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${title ? ` title="${title}"` : ''}>${text}</a>`;
   };
 
   marked.setOptions({

--- a/frontend/src/routes/ContributionTypeDetail.svelte
+++ b/frontend/src/routes/ContributionTypeDetail.svelte
@@ -24,12 +24,21 @@
   let error = $state(null);
   let expandedMissions = $state(new Set());
 
-  // Configure marked options for security
+  // Configure marked options for security and links
+  const renderer = new marked.Renderer();
+  // In marked v5+, the renderer receives a token object
+  renderer.link = function({ href, title, text }) {
+    // Handle undefined/null href values
+    const safeHref = href || '#';
+    return `<a href="${safeHref}" target="_blank" rel="noopener noreferrer"${title ? ` title="${title}"` : ''}>${text}</a>`;
+  };
+
   marked.setOptions({
     breaks: true,
     gfm: true,
     headerIds: false,
-    mangle: false
+    mangle: false,
+    renderer: renderer
   });
 
   // Determine category colors based on contribution type


### PR DESCRIPTION
## Summary
- Fixed undefined and `[object Object]` appearing in markdown links in mission descriptions
- Updated markdown renderer to use marked v16+ API properly

## Root Cause
The `marked` library (v16.3.0) changed its renderer API to pass a token object with destructured parameters `{ href, title, text }` instead of separate arguments. Our renderer was using the old API, causing href values to be received as objects.

## Changes
- Updated link renderer in `Missions.svelte` to use destructured token object
- Updated link renderer in `ContributionTypeDetail.svelte` to use destructured token object
- Added null/undefined href handling to prevent broken links

## Test Plan
- [x] Verified links in mission descriptions now render correctly
- [x] Checked that links open in new tabs with proper security attributes
- [x] Confirmed undefined hrefs fallback to '#' instead of showing 'undefined'